### PR TITLE
Move sentry-sdk to optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ requires-python = ">=3.9"
 dynamic = ["version"]
 dependencies = [
   "wandb>=0.17.1",
-  "sentry-sdk>=2.0.0,<3.0.0",
   "pydantic>=2.0.0",
   "packaging>=21.0",          # For version parsing in integrations
   "tenacity>=8.3.0,!=8.4.0",  # Excluding 8.4.0 because it had a bug on import of AsyncRetrying
@@ -71,6 +70,7 @@ dependencies = [
 # this to a separate package. Note, when that happens, we will need to pull along some of the
 #default dependencies as well.
 wandb = ["wandb>=0.17.1"]
+sentry = ["sentry-sdk>=2.0.0,<3.0.0"]
 trace_server = [
   "ddtrace>=2.7.0",
   # BYOB - S3


### PR DESCRIPTION
## Summary
- Moved `sentry-sdk` from required to optional dependencies to reduce installation footprint
- Added conditional imports with `SENTRY_AVAILABLE` flag to handle missing sentry-sdk gracefully
- All Sentry API calls are now protected with availability checks

## Changes
1. **pyproject.toml**: Moved `sentry-sdk>=2.0.0,<3.0.0` from main dependencies to optional dependencies under `[sentry]` extra
2. **async_batch_processor.py**: Added try/except import with `SENTRY_AVAILABLE` flag and wrapped all sentry calls
3. **trace_sentry.py**: Added conditional imports and guards for all Sentry SDK usage
4. **weave_query/util.py**: Already had proper try/except handling, no changes needed

## Installation
Users who need Sentry integration can install with:
```bash
pip install weave[sentry]
```

## Test plan
- [x] Verified modules load without sentry-sdk installed
- [x] Checked all sentry API calls are guarded with availability checks
- [ ] Run existing tests to ensure no regressions
- [ ] Test with and without sentry-sdk installed

🤖 Generated with [Claude Code](https://claude.ai/code)